### PR TITLE
Clojure deps.edn support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .hg/
 .idea/
 csv2rdf.iml
+.cpcache

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,2 @@
+#!/bin/bash
+clojure -A:dev:logging -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,26 @@
+{
+ :paths ["src"]
+
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/data.json {:mvn/version "0.2.6"}
+        grafter/grafter {:mvn/version "0.11.4"}
+        com.github.fge/uri-template {:mvn/version "0.9"}
+        org.apache.httpcomponents/httpcore {:mvn/version "4.4.9"}
+        clj-http/clj-http {:mvn/version "3.7.0"}
+        org.clojure/tools.cli {:mvn/version "0.3.7"}
+        org.clojure/tools.logging {:mvn/version "0.4.1"}
+        org.slf4j/slf4j-api {:mvn/version "1.7.25"}
+        }
+
+ :aliases {:dev {:extra-paths ["test" "test/resources"]
+                 :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-248"} ;; test runner
+                              org.clojure/test.check {:mvn/version "0.9.0"}
+                              org.clojure/data.csv {:mvn/version "0.1.4"}
+                              }}
+
+           :logging {:extra-deps
+                     {org.apache.logging.log4j/log4j-api {:mvn/version "2.11.0"}
+                      org.apache.logging.log4j/log4j-core {:mvn/version "2.11.0"}
+                      org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.0"}}}
+           }
+ }

--- a/project.clj
+++ b/project.clj
@@ -3,25 +3,13 @@
   :url "https://github.com/Swirrl/csv2rdf"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/data.json "0.2.6"]
-                 [grafter "0.11.4"]
-                 [com.github.fge/uri-template "0.9"]
-                 [org.apache.httpcomponents/httpcore "4.4.9"]
-                 [clj-http "3.7.0"]
-                 [org.clojure/tools.cli "0.3.7"]
-                 [org.clojure/tools.logging "0.4.1"]
-                 [org.slf4j/slf4j-api "1.7.25"]]
-  
+
+  :plugins [[lein-tools-deps "0.4.1"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:install :user :project]}
+
   :profiles
   {:uberjar {:main csv2rdf.main
-             :dependencies [[org.apache.logging.log4j/log4j-api "2.11.0"]
-                            [org.apache.logging.log4j/log4j-core "2.11.0"]
-                            [org.apache.logging.log4j/log4j-slf4j-impl "2.11.0"]]}
-   :dev
-   {:dependencies [[org.clojure/test.check "0.9.0"]
-                   [org.clojure/data.csv "0.1.4"]
-                   [org.apache.logging.log4j/log4j-api "2.11.0"]
-                   [org.apache.logging.log4j/log4j-core "2.11.0"]
-                   [org.apache.logging.log4j/log4j-slf4j-impl "2.11.0"]]
-    :resource-paths ["test/resources"]}})
+             :lein-tools-deps/config {:aliases [:logging]}}
+
+   :dev {:lein-tools-deps/config {:aliases [:dev :logging]}}})


### PR DESCRIPTION
Added `deps.edn` for use with the new clojure command line tools, with a [lein-tools-deps](https://github.com/RickMoynihan/lein-tools-deps) wrapper so we can still use leiningen to build this project.