### PR TITLE
Add kaocha test runner & bump grafter

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+clojure -A:with-logging:test:dev -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure                {:mvn/version "1.9.0"}
         org.clojure/data.json              {:mvn/version "0.2.6"}
-        grafter                            {:mvn/version "2.0.3"}
+        grafter                            {:mvn/version "2.1.7"}
         com.github.fge/uri-template        {:mvn/version "0.9"}
         org.apache.httpcomponents/httpcore {:mvn/version "4.4.9"}
         clj-http                           {:mvn/version "3.7.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -12,8 +12,10 @@
             {org.apache.logging.log4j/log4j-api {:mvn/version "2.11.0"}
              org.apache.logging.log4j/log4j-core {:mvn/version "2.11.0"}
              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.0"}}}
+           :dev {}
            :test
            {:extra-deps
-            {org.clojure/test.check {:mvn/version "0.9.0"}
+            {lambdaisland/kaocha {:mvn/version "0.0-573"}
+             org.clojure/test.check {:mvn/version "0.9.0"}
              org.clojure/data.csv {:mvn/version "0.1.4"}}
             :extra-paths ["test" "test/resources"]}}}


### PR DESCRIPTION
Will need integrated/tested with test fixes to master

- Grafter bump should remove warning on JDK9+