### PR TITLE
Have csv2rdf.source/get-json read file URIs directly instead of attempting an http request

### DIFF
--- a/src/csv2rdf/source.clj
+++ b/src/csv2rdf/source.clj
@@ -32,8 +32,10 @@
 (extend-protocol JSONSource
   URI
   (get-json [uri]
-    (let [{:keys [body]} (http/get-uri uri)]
-      (get-json body)))
+    (if (= (keyword (.getScheme uri)) :file)
+      (read-json uri)
+      (let [{:keys [body]} (http/get-uri uri)]
+        (get-json body))))
 
   File
   (get-json [f] (read-json f))

--- a/test/csv2rdf/source_test.clj
+++ b/test/csv2rdf/source_test.clj
@@ -1,17 +1,24 @@
 (ns csv2rdf.source-test
-  (:require [clojure.test :refer :all]
-            [csv2rdf.source :refer :all]
-            [clojure.data.json :as json]
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.test :refer :all]
             [csv2rdf.http :as http]
+            [csv2rdf.source :refer :all]
             [csv2rdf.test-common :refer [->TestHttpClient]])
-  (:import [java.net URI]))
+  (:import java.net.URI))
 
 (deftest get-json-test
   (testing "URI"
-    (let [uri (URI. "http://example.com")
-          json {"objects" [{"name" "first"} {"name" "second"}]}
-          requests {uri {:body (json/write-str json)}}]
-      (http/with-http-client
-        (->TestHttpClient requests)
-        (let [result (get-json uri)]
-          (is (= json result)))))))
+    (testing "http scheme"
+      (let [uri (URI. "http://example.com")
+            json {"objects" [{"name" "first"} {"name" "second"}]}
+            requests {uri {:body (json/write-str json)}}]
+        (http/with-http-client
+          (->TestHttpClient requests)
+          (let [result (get-json uri)]
+            (is (= json result))))))
+    (testing "file scheme"
+      (let [uri (.toURI (io/file "w3c-csvw/tests/test104.json"))
+            json {}
+            result (get-json uri)]
+        (is (= json result))))))

--- a/test/csv2rdf/source_test.clj
+++ b/test/csv2rdf/source_test.clj
@@ -3,9 +3,10 @@
             [clojure.java.io :as io]
             [clojure.test :refer :all]
             [csv2rdf.http :as http]
-            [csv2rdf.source :refer :all]
+            [csv2rdf.source :refer :all :as source]
             [csv2rdf.test-common :refer [->TestHttpClient]])
-  (:import java.net.URI))
+  (:import java.net.URI
+           [clojure.lang ExceptionInfo]))
 
 (deftest get-json-test
   (testing "URI"
@@ -17,8 +18,17 @@
           (->TestHttpClient requests)
           (let [result (get-json uri)]
             (is (= json result))))))
+
     (testing "file scheme"
       (let [uri (.toURI (io/file "w3c-csvw/tests/test104.json"))
             json {}
             result (get-json uri)]
-        (is (= json result))))))
+        (is (= json result))))
+
+    (testing "unsupported scheme"
+      (let [uri (URI. "unsupported:example.com")]
+        (try
+          (get-json uri)
+          (is false "Expected exception to be thrown")
+          (catch ExceptionInfo ex
+            (is (= ::source/unsupported-uri-scheme-error (:type (ex-data ex))))))))))


### PR DESCRIPTION
You can demonstrate this with e.g.
```
  java -jar target/csv2rdf-0.4.5-SNAPSHOT-standalone.jar \
    -u w3c-csvw/tests/test034/csv-metadata.json \
    -m annotated -o output.ttl
```