### PR TITLE
Use URI of tabular file if provided along with metadata.

### DIFF
--- a/src/csv2rdf/metadata.clj
+++ b/src/csv2rdf/metadata.clj
@@ -24,3 +24,14 @@
 
 (s/fdef parse-table-group-from-source
   :args (s/cat :source (s/and ::source/uriable ::source/json-source)))
+
+(defn ^{:tabular-spec "5.1"} overriding-metadata
+  "Construct an 'overriding metadata' document if the user provides both tabular and
+   user metadata. If the metadata contains a table definition, set the URI to that for
+   the tabular file."
+  [tabular-source metadata-source]
+  (let [json (source/get-json metadata-source)
+        overridden (if (table-group/looks-like-table-group-json? json)
+                     json
+                     (table/override-table-json-uri json (source/->uri tabular-source)))]
+    (source/->MapMetadataSource (source/->uri metadata-source) overridden)))

--- a/src/csv2rdf/metadata/table.clj
+++ b/src/csv2rdf/metadata/table.clj
@@ -34,6 +34,9 @@
 (defn looks-like-table-json? [doc]
   (contains? doc "url"))
 
+(defn override-table-json-uri [doc tabular-uri]
+  (assoc doc "url" (str tabular-uri)))
+
 (defn parse-table-json [context doc]
   (let [t ((contextual-object true table) context doc)]
     (into-table-group t)))

--- a/src/csv2rdf/tabular/processing.clj
+++ b/src/csv2rdf/tabular/processing.clj
@@ -17,17 +17,23 @@
     (table/validate-compatible validating? user-table table-metadata)
     (table/compatibility-merge user-table table-metadata)))
 
+(defn- from-metadata-source [metadata-source]
+  (let [{:keys [tables] :as user-table-group} (meta/parse-table-group-from-source metadata-source)
+        validating? false
+        merged-tables (mapv (fn [table] (validate-merge-table validating? table)) tables)
+        merged-table-group (assoc user-table-group :tables merged-tables)]
+    (set-table-group-parents merged-table-group)))
+
 (defn ^{:tabular-spec "6.1"} get-metadata
   "Retrieves and resolves the metadata given either a tabular data source or metadata source. If user metadata
   is provided, each referenced table definition is validated against the corresponding tabular data file."
   [tabular-source metadata-source]
   (cond
+    (and (some? tabular-source) (some? metadata-source))
+    (from-metadata-source (meta/overriding-metadata tabular-source metadata-source))
+
     (some? metadata-source)
-    (let [{:keys [tables] :as user-table-group} (meta/parse-table-group-from-source metadata-source)
-          validating? false
-          merged-tables (mapv (fn [table] (validate-merge-table validating? table)) tables)
-          merged-table-group (assoc user-table-group :tables merged-tables)]
-      (set-table-group-parents merged-table-group))
+    (from-metadata-source metadata-source)
 
     (some? tabular-source)
     (from-tabular-source tabular-source)

--- a/test/csv2rdf/metadata_test.clj
+++ b/test/csv2rdf/metadata_test.clj
@@ -3,7 +3,8 @@
             [csv2rdf.metadata :refer :all]
             [csv2rdf.source :as source]
             [csv2rdf.metadata.properties :as properties]
-            [csv2rdf.test-common :refer [remove-ns-kws]])
+            [csv2rdf.test-common :refer [remove-ns-kws]]
+            [clojure.java.io :as io])
   (:import [java.net URI]))
 
 (deftest parse-metadata-json-test
@@ -33,3 +34,20 @@
             schema (properties/table-schema table)]
         (is (= {:quoteChar \{} dialect))
         (is (= {:columns [{:name "col1"} {:name "col2"}]} (remove-ns-kws schema)))))))
+
+(deftest overriding-metadata-test
+  (let [test-dir (io/file "w3c-csvw/tests/")]
+    (testing "table group"
+      (let [tabular-source (io/file test-dir "test007.csv")
+            metadata-source (io/file test-dir "test008.json")
+            m (overriding-metadata tabular-source metadata-source)
+            doc (source/get-json m)]
+        (is (= (source/get-json metadata-source) doc))))
+
+    (testing "table"
+      (let [tabular-source (io/file test-dir "test007.csv")
+            metadata-source (io/file test-dir "test022-metadata.json")
+            m (overriding-metadata tabular-source metadata-source)
+            doc (source/get-json m)]
+        (println m)
+        (is (= (get doc "url") (str (source/->uri tabular-source))))))))


### PR DESCRIPTION
Issue #42 - Override the URI of the metadata table if the user also
specifies the tabular data file to process.