### PR TITLE
Initialise NTLMEngineImpl class at runtime

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,6 +23,7 @@ echo "Compiling native-image"
     --no-server \
     --allow-incomplete-classpath \
     --report-unsupported-elements-at-runtime \
+    --initialize-at-run-time=org.apache.http.impl.auth.NTLMEngineImpl \
     -H:ReflectionConfigurationFiles=nativecfg/reflect-config.json \
     "-J-Xmx3g" \
     csv2rdf.main


### PR DESCRIPTION
The NTLMEngineImpl class creates a SecureRandom instance in its
class initialiser so defer initialisation until runtime to avoid
fixing the seed at build time.