### PR TITLE
Resolving metadata fixes

### DIFF
--- a/src/csv2rdf/tabular/metadata.clj
+++ b/src/csv2rdf/tabular/metadata.clj
@@ -135,7 +135,7 @@
 (defmethod get-uri-metadata :file [uri]
   (io-source->embedded-metadata uri))
 
-(defmethod get-uri-metadata :http [uri]
+(defn- fetch-web [uri]
   (let [{:keys [headers ^InputStream stream]} (source/request-input-stream uri)
         metadata-link (get-metadata-link-uri uri headers)]
     (if-let [metadata-doc (resolve-associated-metadata uri metadata-link)]
@@ -146,6 +146,12 @@
             options (dialect/dialect->options dialect)
             rows (reader/make-row-seq stream options)]
         (csv/rows->embedded-metadata uri options rows)))))
+
+(defmethod get-uri-metadata :http [uri]
+  (fetch-web uri))
+
+(defmethod get-uri-metadata :https [uri]
+  (fetch-web uri))
 
 (defprotocol MetadataLocator
   (get-metadata [tabular-source]))

--- a/src/csv2rdf/tabular/metadata.clj
+++ b/src/csv2rdf/tabular/metadata.clj
@@ -82,8 +82,13 @@
     (string/split-lines body)))
 
 (defn ^{:tabular-spec "5.3"} try-get-location-templates [uri]
-  (let [{:keys [body] :as response} (http/get-uri uri)]
-    (if-not (http/is-not-found-response? response)
+  (let [{:keys [body] :as response}
+        (try
+          (http/get-uri uri)
+          (catch clojure.lang.ExceptionInfo exi
+            (select-keys (ex-data exi)
+                         [:status :body])))]
+    (when-not (http/is-not-found-response? response)
       (parse-response-location-templates body))))
 
 (defn try-get-site-wide-configuration-templates [^URI csv-uri]


### PR DESCRIPTION
Fixes #83 and #84.

- `#83` can be recreated by following the reproduction steps in the issue
- `#84` for can be recreated by checking out the commit that fixes `#83` [0e52750](https://github.com/Swirrl/csv2rdf/pull/85/commits/0e52750999bf87ac44da8593aebb196940094d21) and rerunning to see the next error (issue `#84`).