### PR TITLE
Fix logging configuration

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -52,7 +52,7 @@
   "Build an uberjar for the command line app"
   [_]
   (clean nil)
-  (b/copy-dir {:src-dirs ["resources"]
+  (b/copy-dir {:src-dirs ["resources" "profiles/with-logging/resources"]
                :target-dir class-dir})
   (let [basis (b/create-basis {:aliases [:cli :with-logging]})]
     (b/compile-clj {:basis basis

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
             :extra-deps
             {org.apache.logging.log4j/log4j-api {:mvn/version "2.19.0"}
              org.apache.logging.log4j/log4j-core {:mvn/version "2.19.0"}
-             org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.19.0"}}}
+             org.apache.logging.log4j/log4j-slf4j2-impl {:mvn/version "2.19.0"}}}
            :dev {
                  :extra-deps {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}}
 


### PR DESCRIPTION
Issue #322 - Warnings are not being displayed because the log configuration no longer works.

The SLF44 API was updated to version 2, which now uses the service provider API to locate logging implementations. Bindings which target the 1.7 API are ignored.

Change the log4j binding implementation to log4j-slf4j2-impl which target version 2 of the SLF4J API.

Update the build-app task in build.clj to include the resources of the with-logging profile which includes the log4j2.xml configuration file.